### PR TITLE
StepのUI

### DIFF
--- a/src/components/Atoms/NextImage/index.tsx
+++ b/src/components/Atoms/NextImage/index.tsx
@@ -7,7 +7,7 @@ type NextImageProps = {
   spWidth?: number
   spHeight?: number
   spNone?: boolean
-  src: StaticImageData
+  src: string | StaticImageData
   alt: string
 }
 

--- a/src/components/Molecules/StepCard/index.tsx
+++ b/src/components/Molecules/StepCard/index.tsx
@@ -1,0 +1,18 @@
+import NextImage from '@/components/Atoms/NextImage'
+import { Contents } from '@/types/contents'
+import Link from 'next/link'
+import { styles } from './styles'
+
+type StepCardProps = {
+  data?: Contents
+}
+
+const StepCard: React.FC<StepCardProps> = ({ data }) => {
+  return (
+    <div css={styles.base}>
+      <div css={styles.container}>Cardだよ〜</div>
+    </div>
+  )
+}
+
+export default StepCard

--- a/src/components/Molecules/StepCard/index.tsx
+++ b/src/components/Molecules/StepCard/index.tsx
@@ -2,7 +2,7 @@ import NextImage from '@/components/Atoms/NextImage'
 import { Contents } from '@/types/contents'
 import Link from 'next/link'
 import { styles } from './styles'
-
+import DescriptionImagePath from '../../../../assets/images/description-image.png'
 type StepCardProps = {
   data?: Contents
 }
@@ -10,7 +10,28 @@ type StepCardProps = {
 const StepCard: React.FC<StepCardProps> = ({ data }) => {
   return (
     <div css={styles.base}>
-      <div css={styles.container}>Cardだよ〜</div>
+      <div css={styles.container}>
+        <div css={styles.descriptionContainer}>
+          <h2 css={styles.descriptionTitleContainer}>
+            <h2 css={styles.stepNumber}>step1</h2>
+            <h2 css={styles.descriptionTitle}>
+              独学でSEを目指す前に知っておくべきこと
+            </h2>
+          </h2>
+          <div css={styles.description}>
+            SEに必要なスキルや知識は、独学で身につけることが可能なのでしょうか。この記事では、あまり出費をかけずに独学でSEを目指す方法やメリット・デメリット、勉強方法などについて解説します。
+          </div>
+          <div>~ここにボタンを作る~</div>
+        </div>
+        <NextImage
+          src={DescriptionImagePath}
+          width={296}
+          height={192}
+          spWidth={315}
+          spHeight={140}
+          alt="参考"
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/Molecules/StepCard/index.tsx
+++ b/src/components/Molecules/StepCard/index.tsx
@@ -1,33 +1,31 @@
 import NextImage from '@/components/Atoms/NextImage'
+import { Steps } from '@/types/contents'
 import Link from 'next/link'
 import { styles } from './styles'
-import DescriptionImagePath from '../../../../assets/images/description-image.png'
 type StepCardProps = {
-  stepNumber: number
-  title: string
-  excerpt: string
-  imageUrl: string
+  step: Steps
 }
 
-const StepCard: React.FC<StepCardProps> = ({
-  stepNumber,
-  title,
-  excerpt,
-  imageUrl,
-}) => {
+const StepCard: React.FC<StepCardProps> = ({ step }) => {
   return (
     <div css={styles.base}>
       <div css={styles.container}>
         <div css={styles.descriptionContainer}>
           <div css={styles.descriptionTitleContainer}>
-            <h2 css={styles.stepNumber}>step{stepNumber}</h2>
-            <h2 css={styles.descriptionTitle}>{title}</h2>
+            <h2 css={styles.stepNumber}>
+              step
+              <span css={styles.number}>{step.step_number}</span>
+            </h2>
+            <h2 css={styles.descriptionTitle}>{step.title}</h2>
           </div>
-          <div css={styles.description}>{excerpt}</div>
-          <div>~ここにボタンを作る~</div>
+          <div css={styles.description}>{step.excerpt}</div>
+          <Link href={step.id} css={styles.button}>
+            <span>読む</span>
+            <span>→</span>
+          </Link>
         </div>
         <NextImage
-          src={imageUrl}
+          src={step.eyecatch.url}
           width={296}
           height={192}
           spWidth={315}

--- a/src/components/Molecules/StepCard/index.tsx
+++ b/src/components/Molecules/StepCard/index.tsx
@@ -1,30 +1,33 @@
 import NextImage from '@/components/Atoms/NextImage'
-import { Contents } from '@/types/contents'
 import Link from 'next/link'
 import { styles } from './styles'
 import DescriptionImagePath from '../../../../assets/images/description-image.png'
 type StepCardProps = {
-  data?: Contents
+  stepNumber: number
+  title: string
+  excerpt: string
+  imageUrl: string
 }
 
-const StepCard: React.FC<StepCardProps> = ({ data }) => {
+const StepCard: React.FC<StepCardProps> = ({
+  stepNumber,
+  title,
+  excerpt,
+  imageUrl,
+}) => {
   return (
     <div css={styles.base}>
       <div css={styles.container}>
         <div css={styles.descriptionContainer}>
-          <h2 css={styles.descriptionTitleContainer}>
-            <h2 css={styles.stepNumber}>step1</h2>
-            <h2 css={styles.descriptionTitle}>
-              独学でSEを目指す前に知っておくべきこと
-            </h2>
-          </h2>
-          <div css={styles.description}>
-            SEに必要なスキルや知識は、独学で身につけることが可能なのでしょうか。この記事では、あまり出費をかけずに独学でSEを目指す方法やメリット・デメリット、勉強方法などについて解説します。
+          <div css={styles.descriptionTitleContainer}>
+            <h2 css={styles.stepNumber}>step{stepNumber}</h2>
+            <h2 css={styles.descriptionTitle}>{title}</h2>
           </div>
+          <div css={styles.description}>{excerpt}</div>
           <div>~ここにボタンを作る~</div>
         </div>
         <NextImage
-          src={DescriptionImagePath}
+          src={imageUrl}
           width={296}
           height={192}
           spWidth={315}

--- a/src/components/Molecules/StepCard/styles.ts
+++ b/src/components/Molecules/StepCard/styles.ts
@@ -1,0 +1,88 @@
+import { css } from '@emotion/react'
+import makeStyles from '@/styles/makeStyles'
+import { spacing } from '@/styles/spacing'
+import { sp } from '@/styles/breakpoint'
+
+export const styles = makeStyles({
+  base: () => css`
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  `,
+  container: () => css`
+    width: 1120px;
+    ${sp} {
+      width: 345px;
+    }
+  `,
+  titleContainer: () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: ${spacing * 3}px;
+    margin: ${spacing * 10}px 0;
+    ${sp} {
+      flex-direction: column;
+      margin: 0;
+      margin-top: ${spacing * 8}px;
+      margin-bottom: ${spacing * 4}px;
+    }
+  `,
+  title: (theme) => css`
+    font-size: ${theme.typography.heading.size.m};
+    font-weight: ${theme.typography.weight.bold};
+    ${sp} {
+      font-size: ${theme.typography.heading.size.s};
+    }
+  `,
+  descriptionContainer: (theme) => css`
+    display: flex;
+    width: 1120px;
+    height: 320px;
+    background-color: ${theme.color.gray};
+    border-radius: 15px;
+    gap: ${spacing * 4}px;
+    padding: ${spacing * 8}px;
+    margin-bottom: ${spacing * 6}px;
+    ${sp} {
+      flex-direction: column;
+      width: 345px;
+      height: auto;
+      padding: ${spacing * 4}px;
+      margin-bottom: ${spacing * 4}px;
+    }
+  `,
+  descriptionTitle: (theme) => css`
+    font-size: ${theme.typography.heading.size.s};
+    font-weight: ${theme.typography.weight.bold};
+    margin-bottom: ${spacing * 4}px;
+    ${sp} {
+      font-size: ${theme.typography.heading.size.xs};
+      margin-bottom: ${spacing * 2}px;
+    }
+  `,
+  description: (theme) => css`
+    width: 660px;
+    font-size: ${theme.typography.text.size.m};
+    ${sp} {
+      width: 305px;
+      font-size: ${theme.typography.text.size.s};
+    }
+  `,
+  arrowContainer: () => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  `,
+  arrowText: (theme) => css`
+    font-size: ${theme.typography.heading.size.s};
+    font-weight: ${theme.typography.weight.bold};
+    margin-top: ${spacing * 7}px;
+    margin-bottom: ${spacing * 10}px;
+    ${sp} {
+      font-size: ${theme.typography.heading.size.xs};
+      margin-top: ${spacing * 4}px;
+      margin-bottom: ${spacing * 8}px;
+    }
+  `,
+})

--- a/src/components/Molecules/StepCard/styles.ts
+++ b/src/components/Molecules/StepCard/styles.ts
@@ -21,13 +21,19 @@ export const styles = makeStyles({
     ${sp} {
       flex-direction: column-reverse;
       width: 345px;
-      height: 427px;
+      height: 430px;
     }
   `,
   descriptionContainer: (theme) => css`
-    width: 90%;
+    width: 700px;
     margin-right: ${spacing * 5}px;
     background-color: ${theme.color.white};
+    ${sp} {
+      margin-right: 0;
+      width: 315px;
+      flex-direction: column;
+      align-items: flex-start;
+    }
   `,
   descriptionTitleContainer: (theme) => css`
     display: flex;

--- a/src/components/Molecules/StepCard/styles.ts
+++ b/src/components/Molecules/StepCard/styles.ts
@@ -11,59 +11,80 @@ export const styles = makeStyles({
   `,
   container: (theme) => css`
     display: flex;
+    justify-content: center;
     align-items: center;
-    padding: ${spacing * 3}px;
+    gap: ${spacing * 6}px;
     width: 1120px;
     height: 240px;
     background-color: ${theme.color.white};
-    margin-bottom: ${spacing * 5}px;
     border-radius: 20px;
+    margin-bottom: ${spacing * 5}px;
     ${sp} {
       flex-direction: column-reverse;
+      gap: 0;
       width: 345px;
       height: 430px;
     }
   `,
   descriptionContainer: (theme) => css`
-    width: 700px;
-    margin-right: ${spacing * 5}px;
+    width: 650px;
     background-color: ${theme.color.white};
     ${sp} {
-      margin-right: 0;
       width: 315px;
-      flex-direction: column;
-      align-items: flex-start;
     }
   `,
   descriptionTitleContainer: (theme) => css`
     display: flex;
     align-items: center;
     margin-bottom: ${spacing * 2}px;
-    border-bottom: solid ${theme.color.gray};
+    border-bottom: 1px solid ${theme.color.gray};
     ${sp} {
       flex-direction: column;
       align-items: flex-start;
     }
   `,
   stepNumber: (theme) => css`
-    margin-right: ${spacing * 3}px;
     color: ${theme.color.main};
     font-size: ${theme.typography.heading.size.m};
     font-weight: ${theme.typography.weight.bold};
+    margin-right: ${spacing * 3}px;
+  `,
+  number: (theme) => css`
+    font-size: ${theme.typography.heading.size.xl};
+    margin-left: ${spacing * 1}px;
+    ${sp} {
+      font-size: ${theme.typography.heading.size.m};
+    }
   `,
   descriptionTitle: (theme) => css`
     font-size: ${theme.typography.heading.size.s};
     font-weight: ${theme.typography.weight.bold};
     ${sp} {
       font-size: ${theme.typography.heading.size.xs};
-      margin-bottom: ${spacing * 2}px;
     }
   `,
   description: (theme) => css`
-    margin-top: ${spacing * 2}px;
     font-size: ${theme.typography.text.size.m};
+    margin-top: ${spacing * 4}px;
     ${sp} {
       width: 315px;
+      font-size: ${theme.typography.text.size.s};
+      margin-top: 0;
+    }
+  `,
+  button: (theme) => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 150px;
+    height: 40px;
+    background-color: ${theme.color.main};
+    border-radius: 5px;
+    margin-left: auto;
+    font-size: ${theme.typography.text.size.m};
+    font-weight: ${theme.typography.weight.bold};
+    color: ${theme.color.white};
+    ${sp} {
       font-size: ${theme.typography.text.size.s};
     }
   `,

--- a/src/components/Molecules/StepCard/styles.ts
+++ b/src/components/Molecules/StepCard/styles.ts
@@ -9,80 +9,56 @@ export const styles = makeStyles({
     justify-content: center;
     width: 100%;
   `,
-  container: () => css`
-    width: 1120px;
-    ${sp} {
-      width: 345px;
-    }
-  `,
-  titleContainer: () => css`
+  container: (theme) => css`
     display: flex;
-    justify-content: center;
     align-items: center;
-    gap: ${spacing * 3}px;
-    margin: ${spacing * 10}px 0;
+    padding: ${spacing * 3}px;
+    width: 1120px;
+    height: 240px;
+    background-color: ${theme.color.white};
+    margin-bottom: ${spacing * 5}px;
+    border-radius: 20px;
     ${sp} {
-      flex-direction: column;
-      margin: 0;
-      margin-top: ${spacing * 8}px;
-      margin-bottom: ${spacing * 4}px;
-    }
-  `,
-  title: (theme) => css`
-    font-size: ${theme.typography.heading.size.m};
-    font-weight: ${theme.typography.weight.bold};
-    ${sp} {
-      font-size: ${theme.typography.heading.size.s};
+      flex-direction: column-reverse;
+      width: 345px;
+      height: 427px;
     }
   `,
   descriptionContainer: (theme) => css`
+    width: 90%;
+    margin-right: ${spacing * 5}px;
+    background-color: ${theme.color.white};
+  `,
+  descriptionTitleContainer: (theme) => css`
     display: flex;
-    width: 1120px;
-    height: 320px;
-    background-color: ${theme.color.gray};
-    border-radius: 15px;
-    gap: ${spacing * 4}px;
-    padding: ${spacing * 8}px;
-    margin-bottom: ${spacing * 6}px;
+    align-items: center;
+    margin-bottom: ${spacing * 2}px;
+    border-bottom: solid ${theme.color.gray};
     ${sp} {
       flex-direction: column;
-      width: 345px;
-      height: auto;
-      padding: ${spacing * 4}px;
-      margin-bottom: ${spacing * 4}px;
+      align-items: flex-start;
     }
+  `,
+  stepNumber: (theme) => css`
+    margin-right: ${spacing * 3}px;
+    color: ${theme.color.main};
+    font-size: ${theme.typography.heading.size.m};
+    font-weight: ${theme.typography.weight.bold};
   `,
   descriptionTitle: (theme) => css`
     font-size: ${theme.typography.heading.size.s};
     font-weight: ${theme.typography.weight.bold};
-    margin-bottom: ${spacing * 4}px;
     ${sp} {
       font-size: ${theme.typography.heading.size.xs};
       margin-bottom: ${spacing * 2}px;
     }
   `,
   description: (theme) => css`
-    width: 660px;
+    margin-top: ${spacing * 2}px;
     font-size: ${theme.typography.text.size.m};
     ${sp} {
-      width: 305px;
+      width: 315px;
       font-size: ${theme.typography.text.size.s};
-    }
-  `,
-  arrowContainer: () => css`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  `,
-  arrowText: (theme) => css`
-    font-size: ${theme.typography.heading.size.s};
-    font-weight: ${theme.typography.weight.bold};
-    margin-top: ${spacing * 7}px;
-    margin-bottom: ${spacing * 10}px;
-    ${sp} {
-      font-size: ${theme.typography.heading.size.xs};
-      margin-top: ${spacing * 4}px;
-      margin-bottom: ${spacing * 8}px;
     }
   `,
 })

--- a/src/components/Templates/Step/index.tsx
+++ b/src/components/Templates/Step/index.tsx
@@ -1,7 +1,4 @@
-import NextImage from '@/components/Atoms/NextImage'
 import { styles } from './styles'
-import ArrowsImagePath from '../../../../assets/images/arrows.png'
-import { StaticImageData } from 'next/legacy/image'
 import StepCard from '@/components/Molecules/StepCard'
 
 type StepProps = {
@@ -12,7 +9,9 @@ const Step: React.FC<StepProps> = ({ title }) => {
   return (
     <div css={styles.base}>
       <div css={styles.container}>
-        <div css={styles.titleContainer}>{title}</div>
+        <div css={styles.titleContainer}>
+          <h2 css={styles.title}>{title}</h2>
+        </div>
         <StepCard />
         <StepCard />
         <StepCard />

--- a/src/components/Templates/Step/index.tsx
+++ b/src/components/Templates/Step/index.tsx
@@ -14,16 +14,8 @@ const Step: React.FC<StepProps> = ({ title, data }) => {
         <div css={styles.titleContainer}>
           <h2 css={styles.title}>{title}</h2>
         </div>
-        {data.map((item, key) => {
-          return (
-            <StepCard
-              key={key}
-              stepNumber={item.step_number}
-              title={item.title}
-              excerpt={item.excerpt}
-              imageUrl={item.eyecatch.url}
-            />
-          )
+        {data.map((item) => {
+          return <StepCard key={item.id} step={item} />
         })}
       </div>
     </div>

--- a/src/components/Templates/Step/index.tsx
+++ b/src/components/Templates/Step/index.tsx
@@ -1,22 +1,30 @@
 import { styles } from './styles'
 import StepCard from '@/components/Molecules/StepCard'
+import { Steps } from '@/types/contents'
 
 type StepProps = {
   title: string
+  data?: Steps[]
 }
 
-const Step: React.FC<StepProps> = ({ title }) => {
+const Step: React.FC<StepProps> = ({ title, data }) => {
   return (
     <div css={styles.base}>
       <div css={styles.container}>
         <div css={styles.titleContainer}>
           <h2 css={styles.title}>{title}</h2>
         </div>
-        <StepCard />
-        <StepCard />
-        <StepCard />
-        <StepCard />
-        <StepCard />
+        {data.map((item, key) => {
+          return (
+            <StepCard
+              key={key}
+              stepNumber={item.step_number}
+              title={item.title}
+              excerpt={item.excerpt}
+              imageUrl={item.eyecatch.url}
+            />
+          )
+        })}
       </div>
     </div>
   )

--- a/src/components/Templates/Step/index.tsx
+++ b/src/components/Templates/Step/index.tsx
@@ -1,0 +1,26 @@
+import NextImage from '@/components/Atoms/NextImage'
+import { styles } from './styles'
+import ArrowsImagePath from '../../../../assets/images/arrows.png'
+import { StaticImageData } from 'next/legacy/image'
+import StepCard from '@/components/Molecules/StepCard'
+
+type StepProps = {
+  title: string
+}
+
+const Step: React.FC<StepProps> = ({ title }) => {
+  return (
+    <div css={styles.base}>
+      <div css={styles.container}>
+        <div css={styles.titleContainer}>{title}</div>
+        <StepCard />
+        <StepCard />
+        <StepCard />
+        <StepCard />
+        <StepCard />
+      </div>
+    </div>
+  )
+}
+
+export default Step

--- a/src/components/Templates/Step/styles.ts
+++ b/src/components/Templates/Step/styles.ts
@@ -1,0 +1,88 @@
+import { css } from '@emotion/react'
+import makeStyles from '@/styles/makeStyles'
+import { spacing } from '@/styles/spacing'
+import { sp } from '@/styles/breakpoint'
+
+export const styles = makeStyles({
+  base: () => css`
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  `,
+  container: () => css`
+    width: 1120px;
+    ${sp} {
+      width: 345px;
+    }
+  `,
+  titleContainer: () => css`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: ${spacing * 3}px;
+    margin: ${spacing * 10}px 0;
+    ${sp} {
+      flex-direction: column;
+      margin: 0;
+      margin-top: ${spacing * 8}px;
+      margin-bottom: ${spacing * 4}px;
+    }
+  `,
+  title: (theme) => css`
+    font-size: ${theme.typography.heading.size.m};
+    font-weight: ${theme.typography.weight.bold};
+    ${sp} {
+      font-size: ${theme.typography.heading.size.s};
+    }
+  `,
+  descriptionContainer: (theme) => css`
+    display: flex;
+    width: 1120px;
+    height: 320px;
+    background-color: ${theme.color.gray};
+    border-radius: 15px;
+    gap: ${spacing * 4}px;
+    padding: ${spacing * 8}px;
+    margin-bottom: ${spacing * 6}px;
+    ${sp} {
+      flex-direction: column;
+      width: 345px;
+      height: auto;
+      padding: ${spacing * 4}px;
+      margin-bottom: ${spacing * 4}px;
+    }
+  `,
+  descriptionTitle: (theme) => css`
+    font-size: ${theme.typography.heading.size.s};
+    font-weight: ${theme.typography.weight.bold};
+    margin-bottom: ${spacing * 4}px;
+    ${sp} {
+      font-size: ${theme.typography.heading.size.xs};
+      margin-bottom: ${spacing * 2}px;
+    }
+  `,
+  description: (theme) => css`
+    width: 660px;
+    font-size: ${theme.typography.text.size.m};
+    ${sp} {
+      width: 305px;
+      font-size: ${theme.typography.text.size.s};
+    }
+  `,
+  arrowContainer: () => css`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  `,
+  arrowText: (theme) => css`
+    font-size: ${theme.typography.heading.size.s};
+    font-weight: ${theme.typography.weight.bold};
+    margin-top: ${spacing * 7}px;
+    margin-bottom: ${spacing * 10}px;
+    ${sp} {
+      font-size: ${theme.typography.heading.size.xs};
+      margin-top: ${spacing * 4}px;
+      margin-bottom: ${spacing * 8}px;
+    }
+  `,
+})

--- a/src/components/Templates/Step/styles.ts
+++ b/src/components/Templates/Step/styles.ts
@@ -34,6 +34,7 @@ export const styles = makeStyles({
     font-weight: ${theme.typography.weight.bold};
     color: ${theme.color.white};
     ${sp} {
+      width: 345px;
       font-size: ${theme.typography.heading.size.s};
     }
   `,

--- a/src/components/Templates/Step/styles.ts
+++ b/src/components/Templates/Step/styles.ts
@@ -9,10 +9,11 @@ export const styles = makeStyles({
     justify-content: center;
     width: 100%;
   `,
-  container: () => css`
-    width: 1120px;
+  container: (theme) => css`
+    width: 100%;
+    background-color: ${theme.color.main};
     ${sp} {
-      width: 345px;
+      width: 375px;
     }
   `,
   titleContainer: () => css`
@@ -31,58 +32,9 @@ export const styles = makeStyles({
   title: (theme) => css`
     font-size: ${theme.typography.heading.size.m};
     font-weight: ${theme.typography.weight.bold};
+    color: ${theme.color.white};
     ${sp} {
       font-size: ${theme.typography.heading.size.s};
-    }
-  `,
-  descriptionContainer: (theme) => css`
-    display: flex;
-    width: 1120px;
-    height: 320px;
-    background-color: ${theme.color.gray};
-    border-radius: 15px;
-    gap: ${spacing * 4}px;
-    padding: ${spacing * 8}px;
-    margin-bottom: ${spacing * 6}px;
-    ${sp} {
-      flex-direction: column;
-      width: 345px;
-      height: auto;
-      padding: ${spacing * 4}px;
-      margin-bottom: ${spacing * 4}px;
-    }
-  `,
-  descriptionTitle: (theme) => css`
-    font-size: ${theme.typography.heading.size.s};
-    font-weight: ${theme.typography.weight.bold};
-    margin-bottom: ${spacing * 4}px;
-    ${sp} {
-      font-size: ${theme.typography.heading.size.xs};
-      margin-bottom: ${spacing * 2}px;
-    }
-  `,
-  description: (theme) => css`
-    width: 660px;
-    font-size: ${theme.typography.text.size.m};
-    ${sp} {
-      width: 305px;
-      font-size: ${theme.typography.text.size.s};
-    }
-  `,
-  arrowContainer: () => css`
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  `,
-  arrowText: (theme) => css`
-    font-size: ${theme.typography.heading.size.s};
-    font-weight: ${theme.typography.weight.bold};
-    margin-top: ${spacing * 7}px;
-    margin-bottom: ${spacing * 10}px;
-    ${sp} {
-      font-size: ${theme.typography.heading.size.xs};
-      margin-top: ${spacing * 4}px;
-      margin-bottom: ${spacing * 8}px;
     }
   `,
 })

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import HomePage from '@/components/Pages/Home'
 
 export const getStaticProps = async () => {
   const data: Content = await client.get({ endpoint: 'blogs' })
+  console.log(data)
 
   return {
     props: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import HomePage from '@/components/Pages/Home'
 
 export const getStaticProps = async () => {
   const data: Content = await client.get({ endpoint: 'blogs' })
-  console.log(data)
 
   return {
     props: {

--- a/src/pages/step/frontend.tsx
+++ b/src/pages/step/frontend.tsx
@@ -11,7 +11,6 @@ export const getStaticProps = async () => {
     endpoint: 'step',
     queries: { filters: `category[equals]${id}`, orders: 'step_number' },
   })
-  console.log(data.contents)
 
   return {
     props: {

--- a/src/pages/step/frontend.tsx
+++ b/src/pages/step/frontend.tsx
@@ -2,8 +2,29 @@ import JobDescription from '@/components/Templates/JobDescription'
 import EngineerIconPath from '../../../assets/images/engineer-icon.png'
 import DescriptionImagePath from '../../../assets/images/description-image.png'
 import Step from '@/components/Templates/Step'
+import { StepContent, Steps } from '@/types/contents'
+import { client } from '@/lib/client'
 
-const DesignerPage: React.FC = () => {
+export const getStaticProps = async () => {
+  const id = 'uvvyd49h9z'
+  const data: StepContent = await client.get({
+    endpoint: 'step',
+    queries: { filters: `category[equals]${id}`, orders: 'step_number' },
+  })
+  console.log(data.contents)
+
+  return {
+    props: {
+      data: data.contents,
+    },
+  }
+}
+
+type FrontendProps = {
+  data: Steps[]
+}
+
+const FrontendPage: React.FC<FrontendProps> = ({ data }) => {
   return (
     <div>
       <JobDescription
@@ -15,9 +36,9 @@ const DesignerPage: React.FC = () => {
         thumbnailPath={DescriptionImagePath}
         thumbnailAlt="デザイナーの説明画像"
       />
-      <Step title="フロントエンジニアになるステップ" />
+      <Step title="フロントエンジニアになるステップ" data={data} />
     </div>
   )
 }
 
-export default DesignerPage
+export default FrontendPage

--- a/src/pages/step/frontend.tsx
+++ b/src/pages/step/frontend.tsx
@@ -1,5 +1,4 @@
 import JobDescription from '@/components/Templates/JobDescription'
-import { theme } from '@/styles/theme'
 import EngineerIconPath from '../../../assets/images/engineer-icon.png'
 import DescriptionImagePath from '../../../assets/images/description-image.png'
 import Step from '@/components/Templates/Step'
@@ -16,7 +15,7 @@ const DesignerPage: React.FC = () => {
         thumbnailPath={DescriptionImagePath}
         thumbnailAlt="デザイナーの説明画像"
       />
-      <Step title="タイトルだよ〜" />
+      <Step title="フロントエンジニアになるステップ" />
     </div>
   )
 }

--- a/src/pages/step/frontend.tsx
+++ b/src/pages/step/frontend.tsx
@@ -1,0 +1,24 @@
+import JobDescription from '@/components/Templates/JobDescription'
+import { theme } from '@/styles/theme'
+import EngineerIconPath from '../../../assets/images/engineer-icon.png'
+import DescriptionImagePath from '../../../assets/images/description-image.png'
+import Step from '@/components/Templates/Step'
+
+const DesignerPage: React.FC = () => {
+  return (
+    <div>
+      <JobDescription
+        iconPath={EngineerIconPath}
+        iconAlt="エンジニアのアイコン"
+        title="フロントエンドエンジニアになりたい"
+        descriptionTitle="フロントエンドエンジニアとは？"
+        description="SEの仕事は、顧客の要求から仕様を決定し、大まかな設計をするまでの情報システム開発における上流工程を担当します。その際、予算や人員、進捗管理などのマネジメント業務も大切な仕事です。ただし、企業や開発チームによってSEの仕事内容は異なることもあります。SEが担当する上流工程は「要求分析・要件定義」「基本設計」「詳細設計」「テスト」などの業務です。"
+        thumbnailPath={DescriptionImagePath}
+        thumbnailAlt="デザイナーの説明画像"
+      />
+      <Step title="タイトルだよ〜" />
+    </div>
+  )
+}
+
+export default DesignerPage

--- a/src/styles/theme/typography.ts
+++ b/src/styles/theme/typography.ts
@@ -3,6 +3,7 @@ import { Theme } from '@emotion/react'
 export const typography: Theme['typography'] = {
   heading: {
     size: {
+      xl: '40px',
       m: '30px',
       s: '24px',
       xs: '20px',

--- a/src/types/contents.ts
+++ b/src/types/contents.ts
@@ -2,6 +2,10 @@ export type Content = {
   contents: Contents[]
 }
 
+export type StepContent = {
+  contents: Steps[]
+}
+
 export type Contents = {
   category: {
     createdAt: string
@@ -24,6 +28,32 @@ export type Contents = {
   revisedAt: string
   title: string
   updatedAt: string
+}
+
+export type Steps = {
+  id: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+  step_number: number
+  title: string
+  excerpt: string
+  eyecatch: {
+    url: string
+    height: 630
+    width: 1200
+  }
+  contents: string
+  permalink: string
+  category: {
+    id: string
+    createdAt: string
+    updatedAt: string
+    publishedAt: string
+    revisedAt: string
+    name: string
+  }
 }
 
 export type Params = {

--- a/theme.d.ts
+++ b/theme.d.ts
@@ -13,6 +13,7 @@ declare module '@emotion/react' {
     typography: {
       heading: {
         size: {
+          xl: '40px'
           m: '30px'
           s: '24px'
           xs: '20px'


### PR DESCRIPTION
# 実装
StepのUIとAPIを実装しました。以下実装内容一覧です。

- step/frontendページ
- StepComponent(templates)
- StepCardComponent(Molecules)
- API部分は, カテゴリーでfrontendを抽出して, step_numberで昇順にしました
- Stepスキーマの型を作成しました

# 画面

## Web版
<img width="1493" alt="image" src="https://user-images.githubusercontent.com/67491045/211151128-71c14cb5-9940-4113-93d7-93c760655d7a.png">

## SP版
<img width="373" alt="image" src="https://user-images.githubusercontent.com/67491045/211151238-5f0b2c9a-ae38-438c-bcd2-758cba53b4bc.png">

