### PR TITLE
feature: idを使用するのではなくpermalinkの値を使用してurlを生成するように修正

### DIFF
--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -6,7 +6,7 @@ import { NextSeo } from 'next-seo'
 export const getStaticPaths = async () => {
   const data: Content = await client.get({ endpoint: 'blogs' })
 
-  const paths = data.contents.map((content) => `/${content.id}`)
+  const paths = data.contents.map((content) => `/${content.permalink}`)
   return { paths, fallback: false }
 }
 
@@ -26,6 +26,7 @@ type DetailProps = {
 }
 
 const Detail: React.FC<DetailProps> = ({ data }) => {
+  console.log(data)
   return (
     <>
       <NextSeo

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -26,7 +26,6 @@ type DetailProps = {
 }
 
 const Detail: React.FC<DetailProps> = ({ data }) => {
-  console.log(data)
   return (
     <>
       <NextSeo

--- a/src/types/contents.ts
+++ b/src/types/contents.ts
@@ -33,6 +33,7 @@ export type Contents = {
   revisedAt: string
   title: string
   updatedAt: string
+  permalink: string
 }
 
 export type Steps = {


### PR DESCRIPTION
今までmicroCMSから帰ってくるidを使用していたのですが、できれば独自で指定したいため、microCMSでpermalinkという項目を用意し、そこに入ってくる値を使ってパスを生成したいと思っています。
しかしながらうまく動いてくれないので、こちらなぜ動かないのか教えて欲しいです..!